### PR TITLE
Adding support for routing Slack webhooks through egress proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This following properties can be set at the framework or project level:
 * `webhookUrl` - (required) the incoming webhook URL configured in Slack custom integrations.
 * `iconEmoji` - override default bot emoji
 * `username` - override default bot username
+* `proxyHost` - (optional) egress proxy host if outbound requests need to be proxied.
+* `proxyPort` - (required if `proxyHost` is set) egress proxy port.
 
 #### Additional Properties
 The following properties are optional, and can be set at the framework/project

--- a/SlackNotification.groovy
+++ b/SlackNotification.groovy
@@ -78,12 +78,12 @@ def sendMessage(String url, Map message) {
  * @param color the color for the message
  */
 def triggerMessage(Map execution, Map config, String defaultColor) {
-    if (configuration.proxyHost != null && configuration.proxyPort != null) {
-        System.err.println("DEBUG: proxyHost="+configuration.proxyHost)
-        System.err.println("DEBUG: proxyPort="+configuration.proxyPort)
+    if (config.proxyHost != null && config.proxyPort != null) {
+        System.err.println("DEBUG: proxyHost="+config.proxyHost)
+        System.err.println("DEBUG: proxyPort="+config.proxyPort)
         System.getProperties().put("proxySet", "true")
-        System.getProperties().put("proxyHost", configuration.proxyHost)
-        System.getProperties().put("proxyPort", configuration.proxyPort)
+        System.getProperties().put("proxyHost", config.proxyHost)
+        System.getProperties().put("proxyPort", config.proxyPort)
     }
     def expandedTitle = expandString(config.title, [execution: execution])
     def expandedText = expandString(config.additionalText, [execution: execution])

--- a/SlackNotification.groovy
+++ b/SlackNotification.groovy
@@ -78,6 +78,13 @@ def sendMessage(String url, Map message) {
  * @param color the color for the message
  */
 def triggerMessage(Map execution, Map config, String defaultColor) {
+    if (configuration.proxyHost != null && configuration.proxyPort != null) {
+        System.err.println("DEBUG: proxyHost="+configuration.proxyHost)
+        System.err.println("DEBUG: proxyPort="+configuration.proxyPort)
+        System.getProperties().put("proxySet", "true")
+        System.getProperties().put("proxyHost", configuration.proxyHost)
+        System.getProperties().put("proxyPort", configuration.proxyPort)
+    }
     def expandedTitle = expandString(config.title, [execution: execution])
     def expandedText = expandString(config.additionalText, [execution: execution])
     def attachment = [
@@ -151,6 +158,10 @@ rundeckPlugin(NotificationPlugin) {
           defaultValue: false, scope: 'Instance'
 
       color title: 'Color', description: 'Override default message color', scope: 'InstanceOnly'
+
+      proxyHost title:"Proxy host", description:"Outbound proxy", scope:"Project", defaultValue:null, required:false
+
+      proxyPort title:"Proxy port", description:"Outbound proxy port", scope:"Project", defaultValue:null, required:false
   }
   onstart { Map executionData, Map configuration ->
       triggerMessage(executionData, configuration, 'warning')


### PR DESCRIPTION
'proxyHost' and 'proxyPort' are two optional parameters.
If they are set, SlackNotification routes requests through a proxy.
Updated documentation.